### PR TITLE
Add missing dependencies and repository info to package.json

### DIFF
--- a/.changeset/forty-seahorses-do.md
+++ b/.changeset/forty-seahorses-do.md
@@ -1,0 +1,5 @@
+---
+'threlte-uikit': patch
+---
+
+Add missing dependencies and package meta

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "threlte-uikit",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "threlte-uikit",
-      "version": "0.4.3",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "@pmndrs/uikit": "^0.8.4"
+        "@pmndrs/uikit": "^0.8.4",
+        "@preact/signals-core": "^1.5.1"
       },
       "devDependencies": {
         "@changesets/cli": "^2.27.9",
@@ -45,7 +46,8 @@
       },
       "peerDependencies": {
         "@threlte/core": ">=7",
-        "svelte": ">=4"
+        "svelte": ">=4",
+        "three": ">=0.160"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,14 @@
   "version": "0.5.0",
   "license": "MIT",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/michealparks/threlte-uikit.git"
+  },
+  "bugs": {
+    "url": "https://github.com/michealparks/threlte-uikit/issues"
+  },
+  "homepage": "https://github.com/michealparks/threlte-uikit#readme",
   "scripts": {
     "dev": "vite dev",
     "build": "vite build && npm run package",
@@ -29,11 +37,13 @@
     "!dist/**/*.spec.*"
   ],
   "dependencies": {
-    "@pmndrs/uikit": "^0.8.4"
+    "@pmndrs/uikit": "^0.8.4",
+    "@preact/signals-core": "^1.5.1"
   },
   "peerDependencies": {
     "@threlte/core": ">=7",
-    "svelte": ">=4"
+    "svelte": ">=4",
+    "three": ">=0.160"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.9",


### PR DESCRIPTION
Little PR to update `package.json`:

- Add missing dependencies to `dependencies` and `peerDependencies`
    - `@preact/signals-core`
    - `three`
- Add missing repository information so the npm page links back to GitHub

Since deps + peers were being implicitly used from `uikit`, I copied the version ranges from there
